### PR TITLE
Use GITHUB_TOKEN for staging deployments

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
-        ACCESS_TOKEN: ${{ secrets.token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
         FOLDER: _site
         CLEAN: true


### PR DESCRIPTION
I believe that GITHUB_TOKEN now works, so we might consider switching to that, for the basic staging deployments.

It's possible that the access token is still needed for production deployments, and automated site rebuilds, but in theory this could simplify the quick start.

Testing is needed.