### PR TITLE
commit new files from data build

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -43,6 +43,27 @@ jobs:
     - name: Build data
       run: |
         python scripts/build_data.py
+    - name: Check if there are any changes to files
+      id: verify_diff
+      run: |
+        if [[ `git status -s` ]]; then
+          echo "DIFF=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "DIFF=false" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Commit files
+      if: steps.verify_diff.outputs.DIFF == 'true'
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add .
+        git commit -m "Add new progress measure updates"
+    - name: Push changes
+      if: steps.verify_diff.outputs.DIFF == 'true'
+      uses: ad-m/github-push-action@master
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: ${{ github.ref }}
     - name: Place public files
       run: |
         cp public/robots-staging.txt _site/robots.txt


### PR DESCRIPTION
I added a feature to sdg-build that writes the parameters that were used in the progress calculation directly to a yaml file in the data repo, providing the user with added transparency as well as the ability to double-check results. The yaml file needs to be committed and pushed to the repo after the data build. I added some steps to the staging deployment workflow to do just that.

This is an optional addition to the workflow. If someone doesn't add these steps to their workflow, then the output file will simply not be added to their repo.

Test site URL: https://tristanmenard.github.io/site/
Test data repo: https://github.com/tristanmenard/data